### PR TITLE
Add detection toggling for each camera

### DIFF
--- a/application/TFLite_detection_stream.py
+++ b/application/TFLite_detection_stream.py
@@ -31,13 +31,13 @@ classes_idx = 0
 scores_idx = 0
 
 CAMERAS = {
-    # cam_name : [stream, frame]
-    "Driveway" : [None, None],
-    "Front Porch" : [None, None],
-    "SW Yard" : [None, None],
-    "W Porch" : [None, None],
-    "N Yard" : [None, None],
-    "NE Yard" : [None, None]
+    # cam_name : [stream, frame, active]
+    "Driveway" : [None, None, 0],
+    "Front Porch" : [None, None, 0],
+    "SW Yard" : [None, None, 0],
+    "W Porch" : [None, None, 0],
+    "N Yard" : [None, None, 0],
+    "NE Yard" : [None, None, 0]
 }
 
 lock = threading.Lock()
@@ -119,6 +119,7 @@ def detection():
         t1 = cv2.getTickCount()
 
         frames = [] # frames (of any cam) to run detection on
+        keys = list(CAMERAS.keys())
 
         # Grab frame from video stream
         for stream in CAMERAS.keys():
@@ -128,8 +129,10 @@ def detection():
         for idx, f in enumerate(frames):
             # Force only use driveway. This can be removed if we
             # want to add detection on the other cameras.
-            if idx > 0:
-                break
+
+            # Only do detection on selected cameras.
+            if not CAMERAS.get(keys[idx])[2]:
+                continue
 
             # Acquire frame and resize to expected shape [1xHxWx3]
             frame = f

--- a/application/static/styles.css
+++ b/application/static/styles.css
@@ -118,6 +118,11 @@ h1 {
   display: table-cell;
   height: 100%;
 }
+#tableContainer-1-small {
+  height: 100%;
+  width: 20%;
+  display: table;
+}
 .user-table {
   margin: 0 auto; /* center the table */
   border-collapse: collapse; /* remove the cell borders */

--- a/application/templates/settings.html
+++ b/application/templates/settings.html
@@ -86,12 +86,37 @@
           </tr>
           <tbody>
             <tr>
-              <td>Minimum Confidence Threshold<br>(lowest confidence for detection results)</td>
+              <td>Minimum Confidence Threshold<br>(Lowest confidence for detection results)</td>
               <td>
                 <label for="conf_threshold">(percentage): &emsp;</label>
                 <input type="range" id="conf_threshold" name="conf_threshold" class="slider" min="0.1" max="0.9" step="0.1" value="{{ min_conf }}" style="width: 80px;">
                 &emsp;<b id="conf_text">{{ min_conf }}</b>
                 <button id="update" class="button-81" role="button" style="margin-left: 20px;" onclick="updateMinConfidenceThreshold()">Update</button>
+              </td>
+            </tr>
+            <tr>
+              <td style="vertical-align:top;">Enable/Disable Detection<br>(Select cameras to run detection on)</td>
+              <td>
+                <div id="tableContainer-1">
+                  <div id="tableContainer-2">
+                    <table class="user-table" id=tableContainer-1-small>
+                      <!-- <tr>
+                        <th>Camera</th>
+                        <th>Enable/Disable</th>
+                      </tr> -->
+                      <tbody>
+                        {% for cam_name, enabled in cams|zip_detection(cam_statuses) %}
+                          <tr>
+                            <td>{{ cam_name }}</td>
+                            <td>
+                              <input type="checkbox" class="checkbox" detect_status="{{ cam_name }}" {% if enabled %}checked{% endif %} onclick="updateCamDetection(this)">
+                            </td>
+                          </tr>
+                        {% endfor %}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -122,6 +147,28 @@
         })
         .then(function(response) {
           updateSnackbar("SMS notifications updated :O)")
+        })
+        .catch(function(error) {
+          // Handle any errors
+        });
+      }
+
+      function updateCamDetection(checkbox) {
+        // Get the user ID from the "data-user-id" attribute
+        var cam = checkbox.getAttribute('detect_status');
+
+        // Send an HTTP PUT request to the backend to update the user's SMS notifications
+        fetch('/settings/' + cam + '/update-detection', {
+          method: 'PUT',
+          body: JSON.stringify({
+            detection_state: checkbox.checked
+          }),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+        .then(function(response) {
+          updateSnackbar("Camera detection updated :O)")
         })
         .catch(function(error) {
           // Handle any errors

--- a/driver.py
+++ b/driver.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         # print(cam_name)
         channel_str= "channel=" + str(idx + 1)
         stream = VideoStream(resolution=(TFLite_detection_stream.imW,TFLite_detection_stream.imH), framerate=30, stream_url=STREAM_URL.replace("channel=1", channel_str))
-        TFLite_detection_stream.CAMERAS.update({cam_name:[stream.start(), None]})
+        TFLite_detection_stream.CAMERAS.update({cam_name:[stream.start(), None, 0]})
 
     # start a thread that will perform motion detection
     t = threading.Thread(target=TFLite_detection_stream.detection)


### PR DESCRIPTION
# Summary
We wanted the ability to have functionality where we could toggle which cameras we wanted to run detection on, instead of manually having to do this on the backend. This PR adds functionality to do this and also allows users to modify this via the settings endpoint.

## What I did here
- Added backend and frontend changes to add detection toggling on all of our camera feeds.

## How to test
- Pull branch, run algorithm, go to settings, toggle camera's active statuses, verify result on stream.
