### PR TITLE
Notification data privacy 

### DIFF
--- a/application/TFLite_detection_stream.py
+++ b/application/TFLite_detection_stream.py
@@ -127,9 +127,6 @@ def detection():
             frames.append(pic)
 
         for idx, f in enumerate(frames):
-            # Force only use driveway. This can be removed if we
-            # want to add detection on the other cameras.
-
             # Only do detection on selected cameras.
             if not CAMERAS.get(keys[idx])[2]:
                 continue
@@ -165,9 +162,6 @@ def detection():
 
             # Draw framerate in corner of frame
             # cv2.putText(frame,'FPS: {0:.2f}'.format(frame_rate_calc),(30,50),cv2.FONT_HERSHEY_SIMPLEX,1,(255,255,0),2,cv2.LINE_AA)
-
-        # All the results have been drawn on the frame, so it's time to display it.
-        # cv2.imshow('SeamNet', frame) # uncomment for local video display
 
         with lock:
             for idx, cam in enumerate(CAMERAS.keys()):

--- a/application/routes.py
+++ b/application/routes.py
@@ -5,6 +5,7 @@ from application import app
 from application import TFLite_detection_stream
 from application.services import security as vault, sms_service
 from application.services import svc_common
+from application.services import telegram
 from flask import Response, request, make_response, render_template, jsonify
 
 # -------------------------------------------------------------------------------------------------
@@ -66,13 +67,13 @@ def update_sms_status(user):
     # Update the user's record in the database
     vault.put_value("recipients", user, "active", str(sms_status))
 
-    # Send sms notification of status change
+    # Send notification of status change
     if sms_status:
-        # we are opting in to sms notifications
-        sms_service.send_opt_message(user, True, TFLite_detection_stream.FEED_URL + "/settings")
+        # we are opting in to notifications
+        telegram.send_opt_message(user, True, TFLite_detection_stream.FEED_URL + "/settings")
     else:
         # opted out
-        sms_service.send_opt_message(user, False, TFLite_detection_stream.FEED_URL + "/settings")
+        telegram.send_opt_message(user, False, TFLite_detection_stream.FEED_URL + "/settings")
 
     # Return a response to the frontend
     return jsonify({'success': True}), 200

--- a/application/services/svc_common.py
+++ b/application/services/svc_common.py
@@ -5,13 +5,16 @@ from application.services import security as vault
 from application import TFLite_detection_stream
 
 START_TIME = time.time()
-ALERT_TITLE = "SeamBot Alert"
 
-def get_detection_message(camera, timestamp, feed_url):
+def get_detection_message(camera, timestamp, feed_url=None):
     # Remove milliseconds for readability
     timestamp = timestamp.replace(microsecond=0)
 
-    return "{}\n\nPerson detected on {}\n\nat {}\n\nView live feed below:\n{}\n\n(v  '  -- ' )>︻╦╤─ - - - ".format(ALERT_TITLE, camera, str(timestamp), str(feed_url))
+    feed_str = {
+        None : "Visit SeamNet for live viewing."
+    }.get(feed_url, f"For live viewing, click here:\n{str(feed_url)}")
+
+    return f"Person detected on {camera}\n\nat {str(timestamp)}\n\n{feed_str}"
 
 def get_bot_greet_msg():
     return "Hi!\n\nI'm SeamBot, your home assistant.\n\nSee /help for a list of commands that I can respond to."
@@ -25,6 +28,22 @@ def get_bot_forbidden_msg(user_id):
 
 def get_bot_stats_msg():
     return "Here are the stats for SeamNet:"
+
+def get_opt_message(user, opt_in, url=None):
+    verbs = {
+        True : ["into", "out"],
+        False : ["out of", "back in"]
+    }.get(opt_in)
+
+    opt_action = {
+        None: "head to settings."
+    }.get(url, f"click here:\n{url}")
+
+    text = """\
+    %s,\n\nYou have opted %s SeamNet notifications.\n\nTo opt %s, %s
+    """%(user, verbs[0], verbs[1], opt_action)
+
+    return text
 
 def get_active_users_value(field):
     values = []

--- a/driver.py
+++ b/driver.py
@@ -48,6 +48,8 @@ if __name__ == "__main__":
         help="ephemeral port number of the server (1024 to 65535)")
     parser.add_argument('--channels', help='Number of camera channels in the network',
                     default=6)
+    
+    logging.basicConfig(level=logging.INFO)
 
     # Start rotating logger.
     logger = logging.getLogger("Rotating Log")


### PR DESCRIPTION
# Summary
Reworked notification system to mask sensitive data and reuse code between notification services.

## What I did here
- Default to sending opt-in/out messages via Telegram in `routes`
- Reworked `sms_service` to be DRY and cleaner
- Move opt-in/out functionality to `svc_common` to be shared by notification services.
- Reworked `get_opt_message/3` to be much cleaner.
- Other minor changes.

## How to test
-
