### PR TITLE
Add WebSocket for stat stream

### DIFF
--- a/application/routes.py
+++ b/application/routes.py
@@ -1,5 +1,6 @@
 import time
 import datetime
+import json
 
 from application import app
 from application import TFLite_detection_stream
@@ -112,31 +113,26 @@ def video_feed(cam):
 	# return the response generated along with the specific media
 	# type (mime type)
     return Response(TFLite_detection_stream.generate_frame(cam),
-		mimetype = "multipart/x-mixed-replace; boundary=frame")    
-
-# DELETE IF UNUSED
-# @app.route("/active_cam", methods=['POST'])
-# def active_cam():
-#     global active_cam
-#     cam = request.form['active_cam']
-#     active_cam = cam.split("/")[-2]
-    
-#     return cam
+		mimetype = "multipart/x-mixed-replace; boundary=frame")
 
 # -------------------------------------------------------------------------------------------------
 # STATS
 @app.route("/stats")
 def stats():
-    return render_template("stats.html")
+    hostname = vault.get_value("APP", "config", "host")
+    socket_port = vault.get_value("SOCKETS", "stats", "port")
 
+    return render_template("stats.html", host=hostname, port=socket_port)
+
+# Deprecated
+# Can still hit endpoint in browser, but currently unused.
 @app.route("/get_stats")
 def get_stats():
-    global frame_rate_calc
-
     snap = request.args.get('snapshot', None)
 
 	# return the response generated along with the specific media
 	# type (mime type)
+
     def realtime():
         while True:
             yield svc_common.get_server_stats()
@@ -146,5 +142,5 @@ def get_stats():
         return svc_common.get_server_stats(False)
 
     func = realtime if snap == None else snapshot
-    return Response(func(), mimetype='text/plain')
+    return json.dumps(func())
 # -------------------------------------------------------------------------------------------------

--- a/application/services/security.py
+++ b/application/services/security.py
@@ -6,6 +6,7 @@ import env
 
 DISPATCHER = {
     "APP" : env.APP,
+    "SOCKETS" : env.SOCKETS,
     "CAMERAS" : env.CAMERAS,
     "RECIPIENTS" : env.RECIPIENTS,
     "CREDENTIALS" : env.CREDENTIALS,

--- a/application/services/telegram.py
+++ b/application/services/telegram.py
@@ -1,6 +1,5 @@
 import requests
 import logging
-import socket
 
 from telegram import Update
 from telegram.ext import ApplicationBuilder, ContextTypes, CommandHandler, filters
@@ -19,14 +18,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     bot_msg = "<strong>" + svc_common.get_bot_stats_msg() + "</strong>"
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))
-    host = s.getsockname()[0]
-    port = vault.get_value("app", "config", "port")
-
-    stats_url = f'http://{host}:{port}/get_stats?snapshot'
-    stats = (requests.get(stats_url).content).decode("utf-8")
+    stats = svc_common.get_server_stats(False)
     msg = """{}\n\n{}""".format(bot_msg, stats)
 
     await context.bot.sendMessage(chat_id=update.effective_chat.id, 

--- a/application/templates/stats.html
+++ b/application/templates/stats.html
@@ -14,6 +14,7 @@
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+
     <script>
       $(function(){
         $("#navbar").load("../static/navbar.html");
@@ -29,32 +30,20 @@
     </div>
 
     <script>
-      var latest = document.getElementById('stats');
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', "{{ url_for('get_stats') }}", true);
-  
-      xhr.onreadystatechange = function() {
-        var all_lines = xhr.responseText.split('\n');
-        var lines = all_lines.filter(e => e);
+      const uri = "ws://" + "{{ host }}" + ":{{ port }}"
+      const socket = new WebSocket(uri);
 
-        /* The last number should be: lines of stats - 1*/
-        var last_line = (lines.length - 2) - 4;
-        var stats = "<p>";
+      socket.onmessage = function(event) {
+        const data = event.data.split("\n");
+        var lines = data.filter(e => e);
 
-        /* Sentinel value is lines of stats */
-        for (var i = 0; i < 5; i++) {
-          stats += lines[last_line] + "<br><br>";
-          last_line++;
+        var stats = "";
+        for (var i = 0; i < lines.length; i++) {
+          stats += lines[i] + "<br><br>";
         }
 
         document.getElementById('stats').innerHTML = stats;
-
-        if (xhr.readyState == XMLHttpRequest.DONE) {
-          /*alert("The End of Stream");*/
-          latest.textContent = "Video stream offline :O(";
-        }
       };
-      xhr.send();
     </script>
 
   </body>

--- a/application/utils/websockets.py
+++ b/application/utils/websockets.py
@@ -1,0 +1,20 @@
+import asyncio
+import websockets
+
+from application import app
+from application.services import svc_common, security as vault
+
+def start():
+    host = vault.get_value("APP", "config", "host")
+    port = vault.get_value("SOCKETS", "stats", "port")
+
+    start_server = websockets.serve(send_stats, host, port)
+
+    asyncio.get_event_loop().run_until_complete(start_server)
+
+async def send_stats(websocket, path):
+    while True:
+        stats = svc_common.get_server_stats()
+
+        await websocket.send(stats)
+        await asyncio.sleep(0.1)


### PR DESCRIPTION
# Summary
Previously, we were repeatedly sending HTTP get requests every 100th of a second to our backend to retrieve a real-time feed of stats of the network. This has been remedied with a WebSocket approach. 

## What I did here
- Added `websockets.py` under utils
- Refactored front-end code to use this WebSocket
- Small changes to related back-end code

## How to test
-
