### PR TITLE
Add Reminder Scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ snapshot.jpeg
 *.pyc
 init_db.py
 database.db
+test.db
 venv/

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,11 +1,21 @@
+import os
+
 from flask import Flask
 from peewee import SqliteDatabase
 
-# Creates a peewee database instance.
-# Models will use this database to persist information
-database = SqliteDatabase('database.db', pragmas={'foreign_keys': 1})
-
 app = Flask(__name__)
+
+# Determine the environment based on the ENVIRONMENT environment variable
+if 'ENVIRONMENT' in os.environ:
+    environment = os.environ['ENVIRONMENT']
+else:
+    environment = 'production'
+
+# Set up the database based on the environment
+if environment == 'test':
+    database = SqliteDatabase('test.db', pragmas={'foreign_keys': 1})
+else:
+    database = SqliteDatabase('database.db', pragmas={'foreign_keys': 1})
 
 @app.before_request
 def before_request():

--- a/application/models/device.py
+++ b/application/models/device.py
@@ -14,4 +14,4 @@ class Device(BaseModel):
     telemetry_period = IntegerField(default=300)
     status = TextField(default="No device data yet (system delay).")
     created_at = DateTimeField(default=datetime.datetime.now)
-    user = ForeignKeyField(User, backref='devices')
+    user = ForeignKeyField(User, backref='devices', on_delete='CASCADE')

--- a/application/models/reminder.py
+++ b/application/models/reminder.py
@@ -13,4 +13,4 @@ class Reminder(BaseModel):
     recurrence = CharField()
     description = TextField(null=True)
     created_at = DateTimeField(default=date_time.datetime.now)
-    user = ForeignKeyField(User, backref='reminders')
+    user = ForeignKeyField(User, backref='reminders', on_delete='CASCADE')

--- a/application/repository/reminder.py
+++ b/application/repository/reminder.py
@@ -28,6 +28,9 @@ def get_reminder(id=None, user=None):
 
     return reminder()
 
+def get_reminders():
+    return Reminder.select().order_by(Reminder.datetime)
+
 def get_reminders_by_user(user):
     return Reminder.select().where(Reminder.user == user)
 
@@ -45,5 +48,23 @@ def add_reminder(user_id, title, reminder_datetime, recurrence, description=None
 def delete_reminder(reminder_id):
     reminder = Reminder.get(Reminder.id == reminder_id)
     reminder.delete_instance()
+
+    return reminder
+
+def update_datetime(reminder, datetime):
+    reminder.datetime = datetime
+    reminder.save()
+
+    return reminder
+
+def update_recurrence(reminder, recurrence):
+    reminder.recurrence = recurrence
+    reminder.save()
+
+    return reminder
+
+def update_description(reminder, description):
+    reminder.description = description
+    reminder.save()
 
     return reminder

--- a/application/repository/user.py
+++ b/application/repository/user.py
@@ -1,6 +1,25 @@
 from application.models.user import User
 from application.utils.exception_handler import log_exception
 
+def add_user(first_name,
+             phone_number,
+             username,
+             password,
+             sms_notify=1,
+             telegram_notify=1,
+             telegram_chat_id=None):
+    user = User.create(
+        first_name=first_name,
+        phone_number=phone_number,
+        username=username,
+        password=password,
+        sms_notify=sms_notify,
+        telegram_notify=telegram_notify,
+        telegram_chat_id=telegram_chat_id
+    )
+
+    return user
+
 def get_user(id=None,
              first_name=None,
              phone_number=None,

--- a/application/services/scheduler.py
+++ b/application/services/scheduler.py
@@ -1,0 +1,52 @@
+import application.repository.reminder as Reminder
+import application.repository.user as User
+
+from application.services import svc_common, telegram
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+from dateutil.relativedelta import relativedelta
+from functools import partial
+
+# Scheduler for executing background tasks asynchronously
+scheduler = BackgroundScheduler()
+
+def start():
+    for reminder in Reminder.get_reminders():
+        schedule_reminder(reminder)
+
+    scheduler.start()
+
+def schedule_reminder(reminder):
+    user = User.get_user(id=reminder.user_id)
+    message = svc_common.get_reminder_message(reminder)
+    recurrence = reminder.recurrence.lower()
+
+    trigger = lambda interval: set_cron(reminder.datetime + relativedelta(**interval))
+    set_cron = lambda next_run_date: CronTrigger(year=next_run_date.year, month=next_run_date.month,
+                                                day=next_run_date.day, hour=next_run_date.hour,
+                                                minute=next_run_date.minute)
+
+    trigger_mapping = {
+        'none': partial(scheduler.add_job, telegram.send_reminder, 'date',
+                        args=[user.first_name, message], run_date=reminder.datetime),
+        'daily': partial(scheduler.add_job, telegram.send_reminder,
+                         IntervalTrigger(days=1), args=[user.first_name, message]),
+        'bi-weekly': partial(scheduler.add_job, telegram.send_reminder,
+                             IntervalTrigger(weeks=2), args=[user.first_name, message]),
+        'weekly': partial(scheduler.add_job, telegram.send_reminder,
+                          IntervalTrigger(weeks=1), args=[user.first_name, message]),
+        'monthly': partial(scheduler.add_job, telegram.send_reminder,
+                           trigger({'months': 1}), args=[user.first_name, message]),
+        'annually': partial(scheduler.add_job, telegram.send_reminder,
+                            trigger({'years': 1}), args=[user.first_name, message])
+    }
+
+    schedule_job = trigger_mapping.get(recurrence)
+    if schedule_job is None:
+        raise Exception(f"Invalid reminder recurrence: {recurrence}")
+
+    job = schedule_job()
+
+    return job

--- a/application/services/sms_service.py
+++ b/application/services/sms_service.py
@@ -23,7 +23,7 @@ def send_detection_message(camera, timestamp, telegram_chat_id=None):
 
     send_message(text, recipients=recipient)
 
-def send_message(text, img_filename=None, recipients=None):
+def send_message(text, recipients=None, img_filename=None):
     msg = MIMEMultipart()
     msg['Subject'] = "/"
     msg.attach(MIMEText(text))

--- a/application/services/svc_common.py
+++ b/application/services/svc_common.py
@@ -45,6 +45,9 @@ def get_opt_message(user, opt_in, service, url=None):
 
     return text
 
+def get_reminder_message(reminder):
+    return """%s today at %s.\n\n%s"""%(reminder.title, reminder.datetime.time(), reminder.description)
+
 def get_active_users_value(field):
     values = []
 

--- a/application/services/telegram.py
+++ b/application/services/telegram.py
@@ -93,6 +93,21 @@ def send_opt_message(user, opt_in, service, settings_url):
 
     try_exec(__handle_error, response, sms_service.send_opt_message, user, opt_in, service)
 
+def send_reminder(user, message):
+    chat_id = User.get_telegram_chat_id(user)
+    modified_msg = "<strong>Reminder!</strong>\n\n" + message
+
+    params = {
+        'chat_id' : chat_id,
+        'text' : modified_msg,
+        'parse_mode' : "HTML"
+    }
+
+    response = request("post", "sendMessage", params)
+
+    recipient = User.get_phone_number(chat_id, 1)
+    try_exec(__handle_error, response, sms_service.send_message, message, recipient)
+
 def request(method, endpoint, params, files=None):
     """
     Function to make requests to Telegram's bot API.

--- a/driver.py
+++ b/driver.py
@@ -7,11 +7,12 @@ import numpy as np
 import threading
 import logging
 
-from application import app
-from application import TFLite_detection_stream
-from application.services import security as vault
-from application.services import telegram
-from application.services import mqtt
+from application import (app,
+                         TFLite_detection_stream)
+from application.services import (security as vault,
+                                  scheduler,
+                                  telegram,
+                                  mqtt)
 from application.services.video_stream import VideoStream
 from application.utils import websockets
 from logging.handlers import TimedRotatingFileHandler
@@ -170,6 +171,7 @@ if __name__ == "__main__":
     flask_thread.start()
 
     # start services
+    scheduler.start()
     websockets.start()
     mqtt.start()
     telegram.start_bot()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+import os
+
+os.environ['ENVIRONMENT'] = 'test'
+
+from application import database
+from application.models.user import User
+from application.models.device import Device
+from application.models.reminder import Reminder
+
+MODELS = [User, Device, Reminder]
+
+with database:
+    database.drop_tables(MODELS)
+    database.create_tables(MODELS)

--- a/tests/test_services/test_scheduler.py
+++ b/tests/test_services/test_scheduler.py
@@ -1,0 +1,111 @@
+import os
+import sys
+
+# Get the absolute path to the root directory
+root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+sys.path.append(root_path)
+
+import time
+import datetime
+import pytest
+import tests
+
+from application.repository import (reminder as Reminder, user as User)
+from application.services import telegram, scheduler
+from dateutil.relativedelta import relativedelta
+
+SENT_REMINDER = "placeholder"
+
+# Mock function for sending reminders
+def mock_send_reminder(user, message):
+    global SENT_REMINDER
+    SENT_REMINDER = f"Reminder for {user}: {message}"
+
+@pytest.fixture(scope="session")
+def setup_scheduler():
+    scheduler.start()
+
+    # Replace the send_reminder function with the mock
+    telegram.send_reminder = mock_send_reminder
+
+    user = User.add_user(
+        'Baburao',
+        '8881212',
+        'starGarage',
+        'riks'
+    )
+
+    reminder = Reminder.add_reminder(
+        user,
+        'Test Reminder',
+        datetime.datetime.now(),
+        'none',
+    )
+
+    yield reminder
+
+    scheduler.scheduler.remove_all_jobs()
+    scheduler.scheduler.shutdown()
+
+def test_reminder_sending(setup_scheduler):
+    global SENT_REMINDER
+    reminder = setup_scheduler
+    now = datetime.datetime.now() + datetime.timedelta(seconds=2)
+
+    Reminder.update_description(reminder, "Uthale")
+    Reminder.update_datetime(reminder, now)
+
+    scheduler.schedule_reminder(reminder)
+    time.sleep(2)
+
+    assert SENT_REMINDER == f"Reminder for Baburao: Test Reminder today at {now.time()}.\n\nUthale"
+
+def test_reminder_preloading(setup_scheduler):
+    reminder = setup_scheduler
+    now = datetime.datetime.now()
+
+    Reminder.update_datetime(reminder, now)
+    Reminder.update_recurrence(reminder, "daily")
+
+    job = scheduler.schedule_reminder(reminder)
+    assert job.name == "mock_send_reminder"
+
+    scheduler.scheduler.shutdown()
+    scheduler.start()
+
+    jobs = scheduler.scheduler.get_jobs()
+    assert len(jobs) == 1
+    assert jobs[0].name == "mock_send_reminder"
+
+    scheduler.scheduler.remove_all_jobs()
+
+def test_reminder_recurrence_invalid(setup_scheduler):
+    global SENT_REMINDER
+    reminder = setup_scheduler
+    now = datetime.datetime.now() + datetime.timedelta(seconds=2)
+
+    Reminder.update_datetime(reminder, now)
+    Reminder.update_recurrence(reminder, "every-nanosecond")
+
+    with pytest.raises(Exception):
+        scheduler.schedule_reminder(reminder)
+
+@pytest.mark.parametrize("recurrence, timedelta", [("daily", datetime.timedelta(days=1)),
+                                                   ("bi-weekly", datetime.timedelta(weeks=2)),
+                                                   ("weekly", datetime.timedelta(weeks=1)),
+                                                   ("monthly", relativedelta(months=1)),
+                                                   ("annually", relativedelta(years=1))])
+def test_reminder_recurrence(setup_scheduler, recurrence, timedelta):
+    reminder = setup_scheduler
+    now = datetime.datetime.now()
+
+    Reminder.update_datetime(reminder, now)
+    Reminder.update_recurrence(reminder, recurrence)
+
+    job = scheduler.schedule_reminder(reminder)
+
+    next_run_time = job.next_run_time.replace(tzinfo=None).replace(microsecond=0, second=0)
+    expected_next_run_time = (reminder.datetime + timedelta).replace(microsecond=0, second=0)
+
+    assert next_run_time == expected_next_run_time


### PR DESCRIPTION
# Summary
Prior, we could only add and remove reminders. Now, we would like to be able to schedule and send reminders asynchronously. 

## What I did here
- Added `scheduler.py` module to schedule reminders
- Added `test_scheduler.py` for unit tests
- In `add-reminder` route, added logic to schedule the reminder
- In `telegram.py` added logic to send a reminder
- Set up `production` and `test` environments based on env var
- Edited application `__init__.py` and tests `__init__.py` to load relevant db.
- Other misc changes

## How to test
-
