### PR TITLE
Assign Telegram chat id to new users

### DIFF
--- a/application/models/user.py
+++ b/application/models/user.py
@@ -18,5 +18,5 @@ class User(BaseModel):
     password = CharField()
     created_at = DateTimeField(default=datetime.datetime.now)
     sms_notify = IntegerField(default=1)
-    telegram_notify = IntegerField(default=1)
+    telegram_notify = IntegerField(default=0)
     telegram_chat_id = IntegerField(null=True)

--- a/application/repository/user.py
+++ b/application/repository/user.py
@@ -6,7 +6,7 @@ def add_user(first_name,
              username,
              password,
              sms_notify=1,
-             telegram_notify=1,
+             telegram_notify=0,
              telegram_chat_id=None):
     user = User.create(
         first_name=first_name,
@@ -57,6 +57,11 @@ def get_users_by_id_asc():
     """
     return __get_users_order_by(User.id)
 
+def get_ids():
+    users = __get_users_order_by(User.id)
+
+    return [user.id for user in users]
+
 # Add param to indicate if ordering or not.
 def get_first_names():
     users = __get_users_order_by(User.id)
@@ -70,11 +75,10 @@ def get_telegram_chat_ids(active=0):
     if active:
         users = users.where(User.telegram_notify == 1)
 
-    return [user.telegram_chat_id for user in users
-            if user.telegram_chat_id is not None]
+    return [user.telegram_chat_id for user in users]
 
-def get_telegram_chat_id(first_name):
-    return User.get(User.first_name == first_name).telegram_chat_id
+def get_telegram_chat_id(user_id):
+    return User.get(User.id == user_id).telegram_chat_id
 
 # Add param to indicate if ordering or not.
 def get_telegram_notify():
@@ -88,9 +92,9 @@ def get_sms_notify():
 
     return [user.sms_notify for user in users]
 
-def get_phone_number(chat_id=None, active=0, first_name=None):
-    if first_name and not chat_id and not active:
-        return User.get(User.first_name == first_name).phone_number
+def get_phone_number(chat_id=None, active=0, user_id=None):
+    if user_id and not chat_id and not active:
+        return User.get(User.id == user_id).phone_number
     elif chat_id:
         return User.get(User.telegram_chat_id == chat_id and
                         User.sms_notify == active).phone_number
@@ -104,15 +108,21 @@ def get_phone_numbers(active=0):
 
     return [user.phone_number for user in users]
 
-def update_telegram_notify(first_name, status):
-    user = User.get(User.first_name == first_name)
+def update_telegram_notify(user_id, status):
+    user = User.get(User.id == user_id)
     user.telegram_notify = status
 
     user.save()
 
-def update_sms_notify(first_name, status):
-    user = User.get(User.first_name == first_name)
+def update_sms_notify(user_id, status):
+    user = User.get(User.id == user_id)
     user.sms_notify = status
+
+    user.save()
+
+def update_telegram_chat_id(user_id, chat_id):
+    user = User.get(User.id == user_id)
+    user.telegram_chat_id = chat_id
 
     user.save()
 

--- a/application/services/scheduler.py
+++ b/application/services/scheduler.py
@@ -19,7 +19,6 @@ def start():
     scheduler.start()
 
 def schedule_reminder(reminder):
-    user = User.get_user(id=reminder.user_id)
     message = svc_common.get_reminder_message(reminder)
     recurrence = reminder.recurrence.lower()
 
@@ -30,17 +29,17 @@ def schedule_reminder(reminder):
 
     trigger_mapping = {
         'none': partial(scheduler.add_job, telegram.send_reminder, 'date',
-                        args=[user.first_name, message], run_date=reminder.datetime),
+                        args=[reminder.user_id, message], run_date=reminder.datetime),
         'daily': partial(scheduler.add_job, telegram.send_reminder,
-                         IntervalTrigger(days=1), args=[user.first_name, message]),
+                         IntervalTrigger(days=1), args=[reminder.user_id, message]),
         'bi-weekly': partial(scheduler.add_job, telegram.send_reminder,
-                             IntervalTrigger(weeks=2), args=[user.first_name, message]),
+                             IntervalTrigger(weeks=2), args=[reminder.user_id, message]),
         'weekly': partial(scheduler.add_job, telegram.send_reminder,
-                          IntervalTrigger(weeks=1), args=[user.first_name, message]),
+                          IntervalTrigger(weeks=1), args=[reminder.user_id, message]),
         'monthly': partial(scheduler.add_job, telegram.send_reminder,
-                           trigger({'months': 1}), args=[user.first_name, message]),
+                           trigger({'months': 1}), args=[reminder.user_id, message]),
         'annually': partial(scheduler.add_job, telegram.send_reminder,
-                            trigger({'years': 1}), args=[user.first_name, message])
+                            trigger({'years': 1}), args=[reminder.user_id, message])
     }
 
     schedule_job = trigger_mapping.get(recurrence)

--- a/application/services/security.py
+++ b/application/services/security.py
@@ -36,6 +36,9 @@ def get_value(env_var, key, field):
     
     return dec_val
 
+def get_value_encrypted(env_var, key, field):
+    return DISPATCHER.get(env_var.upper()).get(key).get(field)
+
 def get_keys(env_var, key=-1):
     """
     Reads from vault and returns env keys.

--- a/application/services/sms_service.py
+++ b/application/services/sms_service.py
@@ -43,13 +43,14 @@ def send_message(text, recipients=None, img_filename=None):
     # Edge case causes crash if no active recipients.
     if len(recipients) > 0:
         try_exec(server.sendmail, email, recipients, msg.as_string())
+        server.close()
 
-def send_opt_message(user, opt_in, service):
+def send_opt_message(user_id, user_first_name, opt_in, service):
     """
     Sends an SMS message via a carrier through SMTP for opt-in/opt-out.
     """
-    text = svc_common.get_opt_message(user, opt_in, service)
-    recipient = User.get_phone_number(first_name=user)
+    text = svc_common.get_opt_message(user_first_name, opt_in, service)
+    recipient = User.get_phone_number(user_id=user_id)
 
     send_message(text, recipients=recipient)
 

--- a/application/services/svc_common.py
+++ b/application/services/svc_common.py
@@ -16,8 +16,8 @@ def get_detection_message(camera, timestamp, feed_url=None):
 
     return f"Person detected on {camera}\n\nat {str(timestamp)}\n\n{feed_str}"
 
-def get_bot_greet_msg():
-    return "Hi!\n\nI'm SeamBot, your home assistant.\n\nSee /help for a list of commands that I can respond to."
+def get_bot_welcome_msg():
+    return "Hi!\n\nI'm SeamBot, your home assistant.\n\nSetup is now complete. Head back to SeamNet settings to enable notifications."
 
 def get_bot_confirm_msg():
     # Sends a thumbs up emoji
@@ -28,6 +28,9 @@ def get_bot_forbidden_msg(user_id):
 
 def get_bot_stats_msg():
     return "Here are the stats for SeamNet:"
+
+def get_bot_greet_msg():
+    return "Kabira speaking..."
 
 def get_opt_message(user, opt_in, service, url=None):
     verbs = {

--- a/application/static/footer.html
+++ b/application/static/footer.html
@@ -27,15 +27,23 @@
   </footer>
 
   <script>
-    function openTelegram() {
+    function openTelegram(userId) {
+      var hash = sessionStorage.getItem("hash")
+
       // Send an HTTP GET request to the backend for the Telegram bot's username
       fetch('/get_bot_username')
       .then(resp => resp.text())
       .then(data => {
         var bot_username = data.trim();
         var isMobile = /iPhone|iPad|iPod|Android|webOS|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        var webUrl = `https://t.me/${bot_username}?start=start`
-        var appUrl = `tg://resolve?domain=${bot_username}&start=start`;
+
+        var webUrl = `https://t.me/${bot_username}?start=g-${hash}`
+        var appUrl = `tg://resolve?domain=${bot_username}&start=g-${hash}`;
+
+        if (userId != null) {
+          webUrl = `https://t.me/${bot_username}?start=${userId}-${hash}`
+          appUrl = `tg://resolve?domain=${bot_username}&start=${userId}-${hash}`;
+        }
 
         if (isMobile && navigator.userAgent.indexOf("Android") >= 0 && !window.location.hash) {
           setTimeout(function () {

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -10,6 +10,9 @@
   <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  <script type="text/javascript">
+    sessionStorage.setItem("hash", "{{ hash }}");
+  </script>
 
   <link rel="stylesheet" href="../static/styles.css">
 

--- a/application/templates/settings.html
+++ b/application/templates/settings.html
@@ -10,6 +10,9 @@
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      sessionStorage.setItem("hash", "{{ hash }}");
+    </script>
 
     <link rel="stylesheet" href="../static/styles.css">
   </head>
@@ -28,18 +31,18 @@
             <th>User</th>
             <th>Phone</th>
             <th>Telegram Notifications</th>
-            <th>SMS Notifications</th>
+            <th>SMS Notifications (backup)</th>
           </tr>
           <tbody>
-            {% for user, num, status1, status2 in users|zip(phone_nums, telegram_statuses, sms_statuses) %}
+            {% for user, id, num, status1, status2, chat_id in users|zip(ids, phone_nums, telegram_statuses, sms_statuses, chat_ids) %}
               <tr>
                 <td>{{ user }}</td>
                 <td>{{ num }}</td>
                 <td>
-                  <input type="checkbox" name="telegram_notifications" class="checkbox" data-user-id="{{ user }}" {% if status1 %}checked{% endif %} onclick="updateNotifications(this, 'Telegram')">
+                  <input type="checkbox" name="telegram_notifications" class="checkbox" first-name="{{ user }}" user-id="{{ id }}" chat-id="{{ chat_id }}" {% if status1 %}checked{% endif %} onclick="updateNotifications(this, 'Telegram')">
                 </td>
                 <td>
-                  <input type="checkbox" name="sms_notifications" class="checkbox" data-user-id="{{ user }}" {% if status2 %}checked{% endif %} onclick="updateNotifications(this, 'SMS')">
+                  <input type="checkbox" name="sms_notifications" class="checkbox" first-name="{{ user }}" user-id="{{ id }}" {% if status2 %}checked{% endif %} onclick="updateNotifications(this, 'SMS')">
                 </td>
               </tr>
             {% endfor %}
@@ -143,11 +146,21 @@
 
     <script>
       function updateNotifications(checkbox, service) {
-        // Get the user ID from the "data-user-id" attribute
-        var user = checkbox.getAttribute('data-user-id');
+        var user = checkbox.getAttribute('first-name');
+        var user_id= checkbox.getAttribute('user-id');
+        var chat_id = checkbox.getAttribute('chat-id');
+
+        if (service == "Telegram" && chat_id == 'None') {
+          checkbox.checked = false;
+          openTelegram(user_id)
+          setTimeout(function(){
+            window.location.reload();
+          }, 10000);
+          return;
+        }
 
         // Send an HTTP PUT request to the backend to update the user's notifications
-        fetch('/users/' + user + '/' + service + '/notifications', {
+        fetch('/users/' + user_id + '/' + service + '/notifications', {
           method: 'PUT',
           body: JSON.stringify({
             notification_status: checkbox.checked

--- a/tests/test_services/test_scheduler.py
+++ b/tests/test_services/test_scheduler.py
@@ -18,9 +18,9 @@ from dateutil.relativedelta import relativedelta
 SENT_REMINDER = "placeholder"
 
 # Mock function for sending reminders
-def mock_send_reminder(user, message):
+def mock_send_reminder(_, message):
     global SENT_REMINDER
-    SENT_REMINDER = f"Reminder for {user}: {message}"
+    SENT_REMINDER = message
 
 @pytest.fixture(scope="session")
 def setup_scheduler():
@@ -38,7 +38,7 @@ def setup_scheduler():
 
     reminder = Reminder.add_reminder(
         user,
-        'Test Reminder',
+        'Evict Raju',
         datetime.datetime.now(),
         'none',
     )
@@ -59,7 +59,7 @@ def test_reminder_sending(setup_scheduler):
     scheduler.schedule_reminder(reminder)
     time.sleep(2)
 
-    assert SENT_REMINDER == f"Reminder for Baburao: Test Reminder today at {now.time()}.\n\nUthale"
+    assert SENT_REMINDER == f"Evict Raju today at {now.time()}.\n\nUthale"
 
 def test_reminder_preloading(setup_scheduler):
     reminder = setup_scheduler


### PR DESCRIPTION
# Summary
We want a way to be able to dynamically assign users a telegram chat id when they initially interact with the telegram bot. This is more practical than manually inserting chat ids into the db.

## What I did here
Main feature introduced comprises of the following:

- **Important** `telegram_notify` now defaults to 0 since new users wont have a `telegram_chat_id`.
- Unrestricted the bot's `/start` command to enable new users to hit `/start` when enabling telegram notifications.
- Added an encrypted value that is then also hashed for identifying users who are coming to the bot from local app. This will restrict anonymous users from hitting the `/start` command via GUI or requests.
- Assign the telegram chat id to the new user via their `user_id`.
- Added two messages for `/start` command. Setup instructions for new users, and a greeting when no longer a new user.
-  Removed user whitelist function and replaced with `restricted` decorator to restrict non-authorized users from hitting the rest of the bot commands.

Refactored all repo code that was using user `first_name` as a parameter to instead use `user_id`.

## How to test
-
