### PR TITLE
Device auto discovery

### DIFF
--- a/application/models/device.py
+++ b/application/models/device.py
@@ -11,6 +11,7 @@ class BaseModel(Model):
 class Device(BaseModel):
     name = CharField()
     is_on = BooleanField(default=True)
+    ip_address = CharField()
     telemetry_period = IntegerField(default=300)
     status = TextField(default="No device data yet (system delay).")
     created_at = DateTimeField(default=datetime.datetime.now)

--- a/application/repository/device.py
+++ b/application/repository/device.py
@@ -4,6 +4,7 @@ from application.utils.exception_handler import log_exception
 
 def get_device(id=None,
              name=None,
+             ip_address=None,
              user=None):
     """
     Returns a device based on a single given parameter.
@@ -14,7 +15,7 @@ def get_device(id=None,
     :param user: a User record.
     """
 
-    params = [id, name, user]
+    params = [id, name, ip_address, user]
 
     non_null_count = sum(param is not None for param in params)
 
@@ -26,6 +27,7 @@ def get_device(id=None,
     device = {
         id: lambda: Device.get(Device.id == id),
         name: lambda: Device.get(Device.name == name),
+        ip_address: lambda: Device.get(Device.ip_address == ip_address),
         user: lambda: Device.get(Device.user == user),
     }[next(filter(lambda param: param is not None, params))]
 
@@ -43,9 +45,12 @@ def get_device_by_user(user_id, device_name=None):
 def get_devices_by_user(user_id):
     return Device.select().where(Device.user_id == user_id)
 
-def add_device(user_id, name):
+def get_ip_addresses():
+    return [d.ip_address for d in get_devices()]
+
+def add_device(user_id, name, ip_address):
     user = User.get_user(id=user_id)
-    device = Device.create(user = user, name = name)
+    device = Device.create(user = user, name = name, ip_address = ip_address)
 
     return device
 

--- a/application/static/styles.css
+++ b/application/static/styles.css
@@ -143,7 +143,6 @@ h1 {
   border-radius: 1.5rem;
   box-sizing: border-box;
   color: #0d172a;
-  cursor: pointer;
   display: inline-block;
   font-family: "Basier circle",-apple-system,system-ui,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
   font-size: 1.1rem;
@@ -159,7 +158,8 @@ h1 {
   -webkit-user-select: none;
   touch-action: manipulation;
 }
-.button-81:hover {
+.button-81:hover:enabled {
+  cursor: pointer;
   background-color: #2e3f59;
   color: #fff;
   transform: scale(1.2);

--- a/application/templates/devices.html
+++ b/application/templates/devices.html
@@ -75,6 +75,11 @@
         <table class="user-table" style="margin-top: 50px; width: 80%; height: auto">
           <tr>
             <th>User</th>
+            <th>Search
+              <button id="scan" class="button-81" role="button" style="margin: 0px 0px 0px 0px; transform: scale(0.6);" onclick="scan()">
+                <i class="fas fa-search"></i>
+              </button>
+            </th>
             <th>IP Address</th>
             <th>Name</th>
           </tr>
@@ -89,8 +94,15 @@
                 </select>
               </td>
               <td>
+                <select id="deviceDropDown" onclick="populateIpAddress()" onchange="populateIpAddress()">
+                  <option value="--select--" selected="selected">--select--</option>
+                  {% for ip in scanned_devices %}
+                    <option value="{{ ip }}">{{ ip }}</option>
+                  {% endfor %}
+                </select>
+              </td>
+              <td>
                 <input type="text" id="ipAddressInput" pattern="\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}" placeholder="x.x.x.x" required>
-                <span class="info" style="color: rgb(106, 173, 255)">(Plug IP)</span>
               </td>
               <td>
                 <input type="text" id="nameInput" pattern="[A-Za-z]+" placeholder="Thermonuclear reactor" required>
@@ -98,7 +110,7 @@
               </td>
             </tr>
             <tr>
-              <td colspan="3">
+              <td colspan="4">
                 <button id="add" class="button-81" role="button" style="margin-left: 10px; width: 150px;" onclick="addDevice()">&#x2B;</button>
               </td>
             </tr>
@@ -169,6 +181,14 @@
           // Handle any errors
           updateSnackbar(error, "red")
         });
+      }
+
+      function populateIpAddress() {
+        var scanned_ip = document.getElementById("deviceDropDown").value;
+
+        if (scanned_ip != "--select--") {
+          document.getElementById("ipAddressInput").value = scanned_ip;
+        }
       }
 
       function addDevice() {
@@ -251,6 +271,29 @@
         })
         .catch((error) => {
           updateSnackbar(error, "red")
+        });
+      }
+
+      function scan() {
+        document.getElementById("scan").disabled = true;
+        document.body.style.cursor = 'wait';
+
+        $.getJSON("/devices/scan", function(response){
+          if (!response.error) {
+            var dropdown = $("#deviceDropDown");
+            dropdown.empty();
+
+            $.each(response.devices, function(key, value) {
+              dropdown.append($("<option></option>").attr("value", value).text(value));
+            });
+            populateIpAddress();
+
+          } else {
+            updateSnackbar(response.error, "coral")
+          }
+
+          document.body.style.cursor = 'default';
+          document.getElementById("scan").disabled = false;
         });
       }
 


### PR DESCRIPTION
# Summary
Previously, we needed to know the IP address of the device we wanted to add. Now we can also auto discover available devices on the network. 

## What I did here
- Introduced `ip_address` field to `Device` schema
- Assign `ip_address` on Device creation
- Use this new `ip_address` to ensure only IP address that are not associated with an existing device will show up in the auto discovery
- Scan for IP addresses on LAN using address resolution protocol and checking if it is a Tasmota device.
- Added search box under `Add a Device` section in frontend.
- `IP Address` input box auto populates on frontend if user selects an IP address from the search results box.

## How to test
-
