### PR TITLE
Add sensor models and user sensors

### DIFF
--- a/application/models/sensor.py
+++ b/application/models/sensor.py
@@ -1,0 +1,48 @@
+import datetime
+
+from peewee import (Model, CharField, DateTimeField, FloatField, 
+                    ForeignKeyField, PeeweeException)
+from application import database
+from application.models.user import User
+
+class BaseModel(Model):
+    class Meta:
+        database = database
+
+class Sensor(BaseModel):
+    location = CharField()
+    ip_address = CharField()
+    firmware = CharField()
+    created_at = DateTimeField(default=datetime.datetime.now)
+    user = ForeignKeyField(User, backref='sensors', on_delete='CASCADE')
+
+class TemperatureSensor(Sensor):
+    name = CharField()
+    temperature = FloatField(default=0)
+    temp_unit = CharField(default="F")
+    temp_delta_threshold = FloatField(default=0.5)
+    temp_offset = FloatField(default=0)
+    humidity = FloatField(default=0)
+    humidity_delta_threshold = FloatField(default=5)
+    humidity_offset = FloatField(default=0)
+    sensor = ForeignKeyField(Sensor, backref='temperature_sensors', on_delete='CASCADE')
+
+    @classmethod
+    def create_with_sensor(cls, location, ip_address, firmware, user, **kwargs):
+        with database.atomic() as transaction:
+            try:
+                sensor = Sensor.create(
+                    location=location,
+                    ip_address=ip_address,
+                    firmware=firmware,
+                    user=user
+                )
+                return cls.create(sensor=sensor, location=location, ip_address=ip_address,
+                                firmware=firmware, user=user, **kwargs)
+            except PeeweeException:
+                transaction.rollback()
+
+    @classmethod
+    def delete_with_sensor(cls, temperature_sensor):
+        sensor = Sensor.get(id=temperature_sensor.sensor.id)
+        Sensor.delete_instance(sensor)

--- a/application/repository/device.py
+++ b/application/repository/device.py
@@ -60,20 +60,20 @@ def delete_device(device_id):
 
     return device
 
-def update_status(user_id, name, status):
-    device = Device.get(Device.user_id == user_id and Device.name == name)
+def update_status(device_id, status):
+    device = Device.get(Device.id == device_id)
     device.status = status
 
     device.save()
 
-def update_is_on(user_id, name, state):
-    device = Device.get(Device.user_id == user_id and Device.name == name)
+def update_is_on(device_id, state):
+    device = Device.get(Device.id == device_id)
     device.is_on = state
 
     device.save()
 
-def update_telemetry_period(user_id, device_id, new_period):
-    device = Device.get(Device.user_id == user_id and Device.id == device_id)
+def update_telemetry_period(device_id, new_period):
+    device = Device.get(Device.id == device_id)
     device.telemetry_period = new_period
 
     device.save()

--- a/application/repository/temperature_sensor.py
+++ b/application/repository/temperature_sensor.py
@@ -1,0 +1,62 @@
+from application.models.sensor import TemperatureSensor
+from application.repository import user as User
+from application.utils.exception_handler import log_exception
+
+def get_sensor(id=None,
+               ip_address=None,
+               sensor=None,
+               user=None):
+    """
+    Returns a temperature sensor based on a single given parameter.
+
+    **IMPORTANT**: Can only pass in one
+    parameter, otherwise None is returned.
+
+    :param sensor: a Sensor record.
+    :param user: a User record.
+    """
+
+    params = [id, ip_address, sensor, user]
+
+    non_null_count = sum(param is not None for param in params)
+
+    if non_null_count != 1:
+        e = ValueError('application/repository/temperature_sensor.py: Exactly one parameter must be non-null')
+        log_exception(e)
+        return None
+
+    temperature_sensor = {
+        id: lambda: TemperatureSensor.get(TemperatureSensor.id == id),
+        ip_address: lambda: TemperatureSensor.get(TemperatureSensor.ip_address == ip_address),
+        sensor: lambda: TemperatureSensor.get(TemperatureSensor.sensor == sensor),
+        user: lambda: TemperatureSensor.get(TemperatureSensor.user == user),
+    }[next(filter(lambda param: param is not None, params))]
+
+    return temperature_sensor()
+
+def get_sensors():
+    return TemperatureSensor.select()
+
+def get_sensors_by_user(user_id):
+    return TemperatureSensor.select().where(TemperatureSensor.user_id == user_id)
+
+def add_sensor(user_id, name, location, ip_address, firmware):
+    user = User.get_user(id=user_id)
+    sensor = TemperatureSensor.create_with_sensor(user=user, name=name, location=location,
+                                                  ip_address=ip_address, firmware=firmware)
+
+    return sensor
+
+def delete_sensor(id):
+    temp_sensor = TemperatureSensor.get(TemperatureSensor.id == id)
+    TemperatureSensor.delete_with_sensor(temp_sensor)
+
+    return temp_sensor
+
+def get_ip_addresses():
+    return [s.ip_address for s in get_sensors()]
+
+def update_temperature(sensor, temperature):
+    sensor.temperature = temperature
+
+    sensor.save()

--- a/application/services/telegram/telegram.py
+++ b/application/services/telegram/telegram.py
@@ -27,6 +27,7 @@ def start_bot():
 
     # Add new bot commands here
     commands = {
+        dispatcher.start : "Introduction and greeting",
         dispatcher.server : f"Get {moniker}Net server stats",
         dispatcher.toggle : "Toggle your device power",
         dispatcher.status : "Get your device status",

--- a/application/static/footer.html
+++ b/application/static/footer.html
@@ -15,14 +15,23 @@
     <div class="container">
         <p class="text">SeamNet Services &reg;</p>
         <div>
+          <a href="/">
+            <img src="https://th.bing.com/th/id/R.78b53aba80711ecf9389815f4f8abfdf?rik=wFctHGmQwpl%2bvQ&pid=ImgRaw&r=0" class="logo">
+          </a>
+          <a href="stats">
+            <img src="https://th.bing.com/th/id/R.72d5e0371bcc67e16fc9879377771a62?rik=FFdwwNFVb%2b45Xw&riu=http%3a%2f%2fguy.pastre.org%2fwp-content%2fuploads%2f2016%2f03%2fRaspberry_Pi_Logo.svg.png&ehk=5j%2fMwdf3B%2f5oeOY9E4zg801GfBohZmw5OjVjjxaDiDg%3d&risl=&pid=ImgRaw&r=0" class="logo">
+          </a>
+          <a href="devices">
+            <img src="https://apps-cdn.athom.com/app/com.paveld.tasmota/17/416f22d3-812c-4d53-81d3-6637f54e5f74/drivers/tasmota_mqtt/assets/images/large.png" class="logo">
+          </a>
+          <a href="sensors">
+            <img src="https://cdn-1.webcatalog.io/catalog/shelly/shelly-icon-filled.png?v=1652200955375" class="logo">
+          </a>
           <a href="#" onclick="openTelegram()">
             <img src="https://pngimg.com/uploads/telegram/telegram_PNG20.png" class="logo">
           </a>
-          <img src="https://apps-cdn.athom.com/app/com.paveld.tasmota/17/416f22d3-812c-4d53-81d3-6637f54e5f74/drivers/tasmota_mqtt/assets/images/large.png" class="logo">
-          <img src="https://th.bing.com/th/id/R.72d5e0371bcc67e16fc9879377771a62?rik=FFdwwNFVb%2b45Xw&riu=http%3a%2f%2fguy.pastre.org%2fwp-content%2fuploads%2f2016%2f03%2fRaspberry_Pi_Logo.svg.png&ehk=5j%2fMwdf3B%2f5oeOY9E4zg801GfBohZmw5OjVjjxaDiDg%3d&risl=&pid=ImgRaw&r=0" class="logo">
-          <img src="https://th.bing.com/th/id/R.78b53aba80711ecf9389815f4f8abfdf?rik=wFctHGmQwpl%2bvQ&pid=ImgRaw&r=0" class="logo">
         </div>
-        <p class="text">Copyright &copy; 2023 Seam | All Rights Reserved</p>
+        <p class="text">&copy; 2023 Seam | All Rights Reserved</p>
     </div>
   </footer>
 

--- a/application/static/navbar.html
+++ b/application/static/navbar.html
@@ -6,13 +6,14 @@
   <meta http-equiv="Expires" content="0"/>
 
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css">
 
   <script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
   <script>
     $(function(){
         $('a').each(function(){
             if ($(this).prop('href') == window.location.href) {
-                $(this).addClass('active'); $(this).parents('li').addClass('active');
+                $(this).addClass('active');
             }
         });
     });
@@ -22,15 +23,28 @@
   <!-- Header -->
   <header class="header">
     <img src="https://media.istockphoto.com/vectors/cute-smiling-robot-chat-bot-say-hivector-modern-flat-cartoon-voice-vector-id1073076312?k=6&m=1073076312&s=612x612&w=0&h=bx1_BlqwV32YaMHEw0gvlG7wmwAM00I1t4kSD4FKcck=" class="logo">
-    <nav>
-      <ul>
-        <li><a href="/" id="home-link">Home</a></li>
-        <li><a href="stats" id="stats-link">Stats</a></li>
-        <li><a href="devices" id="devices-link">Devices</a></li>
-        <li><a href="reminders" id="reminders-link">Reminders</a></li>
-        <li><a href="settings" id="settings-link">Settings</a></li>
-      </ul>
-    </nav>
+    <div class="nav">
+      <a href="/">Home</a>
+      <a href="stats">Stats</a>
+      <a href="reminders">Reminders</a>
+
+      <div class="dropdown">
+        <button class="dropbtn">
+          <a>
+            Automation
+            <i class="fa fa-caret-down"></i>
+          </a>
+        </button>
+        <div class="dropdown-content">
+          <a href="devices">Devices</a>
+          <a href="sensors">Sensors</a>
+        </div>
+      </div>
+
+      <div class="nav-right">
+        <a href="settings" class="setting-icon" style="color:coral;"><i class="fas fa-user-cog"></i></a>
+      </div>
+    </div>
   </header>
 
 </body>

--- a/application/static/styles.css
+++ b/application/static/styles.css
@@ -1,4 +1,4 @@
-/* NAVBAR */
+/* BODY */
 html, body {
   height: 100%;
 }
@@ -16,21 +16,10 @@ body {
   /* position: fixed; */
   left: 0;
   width: 100%;
-  height: 150px;
+  height: 140px;
   background-color: #fff;
   box-shadow: 0 3px 7px rgba(0, 0, 0, 0.1);
   z-index: 1;
-}
-.logo {
-  cursor: pointer;
-  width: auto;
-  height: 130px;
-  float: left;
-  margin: auto 20px;
-  transition: transform 0.2s ease-in-out;
-}
-.logo:hover {
-  transform: scale(1.2);
 }
 .title {
   font-size: 24px;
@@ -70,33 +59,70 @@ body {
 }
 
 /* Navigation styles */
-nav {
-  display: flex;
-  align-items: center;
-  height: 100%;
+.logo {
+  cursor: pointer;
+  width: auto;
+  height: 130px;
+  float: left;
+  margin: auto 20px;
+  transition: transform 0.2s ease-in-out;
 }
-nav ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  height: 100%;
+.logo:hover {
+  transform: scale(1.15);
 }
-nav li {
-  margin: 0 10px;
+.nav {
+  align-items: center;
+  overflow: hidden;
+}
+.nav-right {
+  margin: auto 30px;
+  float: right;
+}
+.nav a {
+  margin: 35px 10px auto auto;
+  float: left;
+  text-align: center;
+  padding: 14px 16px;
+  text-decoration: none;
   font-size: 30px;
 }
-nav a {
-  display: block;
-  padding: 10px 20px;
-  color: #333;
-  text-decoration: none;
+.dropdown {
+  float: left;
+  overflow: hidden;
 }
-nav a.active {
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 230px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+.dropdown .dropbtn {
+  margin: 0;
+  font-size: 30px;
+  border: none;
+  outline: none;
+  background-color: inherit;
+  font-family: inherit;
+  text-align: center;
+}
+.dropdown-content a {
+  margin: 12px;
+  float: none;
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  text-align: center;
+}
+.dropdown:hover .dropdown-content {
+  display: block;
+}
+.nav a.active, .nav-right a.active, .dropdown.active {
   border-bottom: 3px solid rgb(79, 158, 255);
 }
-nav a:hover {
+.nav a:hover, .dropbtn a:hover {
   background-color: #2e3f59;
   color: #ffffff;
   border-radius: 7px;

--- a/application/templates/sensors.html
+++ b/application/templates/sensors.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Pragma" content="no-cache"/>
     <meta http-equiv="Expires" content="0"/>
 
-    <title>{{ server }} - Devices</title>
+    <title>{{ server }} - Sensors</title>
 
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
@@ -19,7 +19,7 @@
     <div id="navbar"></div>
 
     <div>
-      <h1 class="h1">Devices</h1>
+      <h1 class="h1">Sensors</h1>
     </div>
 
     <div id="tableContainer-1">
@@ -27,28 +27,24 @@
         <table class="user-table" style="margin-top: 50px; width: 80%; height: auto">
           <tr>
             <th>User</th>
-            <th>Device</th>
-            <th>Toggle</th>
-            <th>Telemetry Period</th>
+            <th>Location</th>
+            <th>Temperature</th>
+            <th>Unit</th>
+            <th>Temp Delta Thresh</th>
             <th></th>
           </tr>
           <tbody>
-            {% for user in device_data %}
-                {% if device_data[user] %}
-                    {% for device in device_data[user] %}
+            {% for user in sensor_data %}
+                {% if sensor_data[user] %}
+                    {% for sensor in sensor_data[user] %}
                       <tr>
                         <td>{{ user if loop.index == 1 else '' }}</td>
-                        <td>{{ device['name'] }}</td>
+                        <td>{{ sensor['location'] }}</td>
+                        <td>{{ sensor['temperature'] }}</td>
+                        <td>{{ sensor['temp_unit'] }}</td>
+                        <td>{{ sensor['temp_delta_threshold'] }}</td>
                         <td>
-                          <input type="checkbox" class="checkbox" device_id="{{ device['id'] }}" device_name="{{ device['name'] }}" {% if device.state %}checked{% endif %} onclick="toggleDevice(this)">
-                        </td>
-                        <td>
-                          <input type="range" id="telemetry_period" name="telemetry_period" class="slider" min="30" max="300" step="30" value="{{ device['tele_period'] }}" style="width: 80px;" oninput="updateTelemetryText(this)">
-                          &emsp;<b id="period_text">{{ device['tele_period'] }}</b>
-                          <button id="update" class="button-81" role="button" device_id="{{ device['id'] }}" device_name="{{ device['name'] }}" style="margin-left: 10px;" onclick="updateTelemetryPeriod(this)">&#x2713;</button>
-                        </td>
-                        <td>
-                          <button id="delete" class="button-81" role="button" device_id="{{ device['id'] }}" device_name="{{ device['name'] }}" user_firstname = "{{ user }}" style="margin-left: 10px; background-color: rgb(251, 71, 110);" onclick="deleteDevice(this)">
+                          <button id="delete" class="button-81" role="button" sensor_id="{{ sensor['id'] }}" user_firstname = "{{ user }}" style="margin-left: 10px; background-color: rgb(251, 71, 110);" onclick="deleteSensor(this)">
                             <i class="fas fa-trash-alt"></i> <!-- trash can icon -->
                           </button>
                         </td>
@@ -67,7 +63,10 @@
     <br>
 
     <div>
-      <h1 class="h1">Add a Device</h1>
+      <h1 class="h1">Add a Sensor</h1>
+    </div>
+    <div style="text-align: center;">
+      *To add a sensor, ensure it is in setup mode (SET). Setup mode lasts for 3 minutes.
     </div>
 
     <div id="tableContainer-1">
@@ -81,22 +80,21 @@
               </button>
             </th>
             <th>IP Address</th>
-            <th>Name</th>
+            <th>Location</th>
           </tr>
           <tbody>
             <tr>
               <td>
                 <select id="userDropDown">
-                  <!-- Use a for loop to populate the user options -->
                   {% for user in users %}
                     <option value="{{ user.id }}" first_name="{{ user.first_name }}">{{ user.first_name }}</option>
                   {% endfor %}
                 </select>
               </td>
               <td>
-                <select id="deviceDropDown" onclick="populateIpAddress()" onchange="populateIpAddress()">
+                <select id="sensorDropDown" onclick="populateIpAddress()" onchange="populateIpAddress()">
                   <option value="--select--" selected="selected">--select--</option>
-                  {% for ip in scanned_devices %}
+                  {% for ip in scanned_sensors %}
                     <option value="{{ ip }}">{{ ip }}</option>
                   {% endfor %}
                 </select>
@@ -105,13 +103,12 @@
                 <input type="text" id="ipAddressInput" pattern="\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}" placeholder="x.x.x.x" required>
               </td>
               <td>
-                <input type="text" id="nameInput" pattern="[A-Za-z]+" placeholder="Thermonuclear reactor" required>
-                <span class="info" style="color: rgb(106, 173, 255)">(Appliance)</span>
+                <input type="text" id="locationInput" pattern="[A-Za-z]+" placeholder="Reaction chamber" required>
               </td>
             </tr>
             <tr>
               <td colspan="4">
-                <button id="add" class="button-81" role="button" style="margin-left: 10px; width: 150px;" onclick="addDevice()">&#x2B;</button>
+                <button id="add" class="button-81" role="button" style="margin-left: 10px; width: 150px;" onclick="addSensor()">&#x2B;</button>
               </td>
             </tr>
           </tbody>
@@ -136,62 +133,7 @@
     <div id="snackbar">Update successful :O)</div>
 
     <script>
-      function toggleDevice(checkbox) {
-        // Get the device name and id from the checkbox attributes
-        var device_name = checkbox.getAttribute('device_name');
-        var device_id = checkbox.getAttribute('device_id');
-
-        // Send an HTTP PUT request to the backend to toggle the device on or off
-        fetch('/devices/' + device_id + '/toggle')
-        .then((response) => {
-          let msg = ""
-          response.ok ? msg = `${device_name} toggled :O)` :
-                        msg = `Failed to toggle ${device_name} :O(`
-          updateSnackbar(msg, "rgb(121, 196, 137)")
-        })
-        .catch((error) => {
-          // Handle any errors
-          updateSnackbar(error, "red")
-        });
-      }
-
-      function updateTelemetryPeriod(button) {
-        // Get the device name, new telemetry_period,and id from the slider attributes
-        var value = button.parentNode.querySelector('.slider').value;
-        var device_name = button.getAttribute('device_name');
-        var device_id = button.getAttribute('device_id');
-
-        // Send an HTTP PUT request to the backend to update the device's telemetry period
-        fetch('/devices/' + device_id + '/telemetry-period', {
-          method: 'PUT',
-          body: JSON.stringify({
-            new_period: value
-          }),
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        })
-        .then((response) => {
-          let msg = ""
-          response.ok ? msg = `Telemetry period updated for ${device_name} :O)` :
-                        msg = `Failed to update telemetry period for ${device_name} :O(`
-          updateSnackbar(msg, "rgb(121, 196, 137)")
-        })
-        .catch((error) => {
-          // Handle any errors
-          updateSnackbar(error, "red")
-        });
-      }
-
-      function populateIpAddress() {
-        var scanned_ip = document.getElementById("deviceDropDown").value;
-
-        if (scanned_ip != "--select--") {
-          document.getElementById("ipAddressInput").value = scanned_ip;
-        }
-      }
-
-      function addDevice() {
+      function addSensor() {
         document.body.style.cursor = 'wait';
 
         // Get the values from the input boxes
@@ -199,15 +141,15 @@
         var user_id = userDropDown.value;
         var user_firstname = userDropDown.options[userDropDown.selectedIndex].getAttribute("first_name");
         var ipAddress = document.getElementById("ipAddressInput").value;
-        var name = document.getElementById("nameInput").value;
+        var location = document.getElementById("locationInput").value;
 
-        // Send an HTTP PUT request to the backend to add the device for the user
-        fetch('/devices/add-device', {
+        // Send an HTTP PUT request to the backend to add the sensor for the user
+        fetch('/sensors/add', {
           method: 'PUT',
           body: JSON.stringify({
             user_id: user_id,
             ip_address: ipAddress,
-            device_name: name,
+            location: location,
             user_firstname: user_firstname
           }),
           headers: {
@@ -225,30 +167,29 @@
         .then(data => {
           if (data.success) {
             const msg = data.success;
-            localStorage.setItem('deviceAddMessage', msg);
-            location.reload();
+            localStorage.setItem('sensorAddMessage', msg);
+            window.location.reload(true);
           }
         })
         .catch((error) => {
           // Clear the input boxes
           document.getElementById("ipAddressInput").value = "";
-          document.getElementById("nameInput").value = "";
+          document.getElementById("locationInput").value = "";
 
           document.body.style.cursor = 'default';
           updateSnackbar(error, "red")
         });
       }
 
-      function deleteDevice(button) {
-        var device_id = button.getAttribute('device_id');
-        var device_name = button.getAttribute('device_name');
+      function deleteSensor(button) {
+        var sensor_id = button.getAttribute('sensor_id');
         var user_firstname = button.getAttribute('user_firstname')
 
-        // Send an HTTP PUT request to the backend to delete the device for the user
-        fetch('/devices/delete-device', {
+        // Send an HTTP PUT request to the backend to delete the sensor for the user
+        fetch('/sensors/delete', {
           method: 'PUT',
           body: JSON.stringify({
-            device_id: device_id,
+            sensor_id: sensor_id,
             user_firstname: user_firstname
           }),
           headers: {
@@ -259,13 +200,13 @@
           if (response.ok) {
             return response.json();
           }
-          msg = `Failed to delete ${device_name} for ${user_firstname} :O(`
+          msg = `Failed to delete sensor for ${user_firstname} :O(`
           throw new Error(msg);
         })
         .then((data) => {
           if (data.success) {
             const msg = data.success;
-            localStorage.setItem('deviceDeleteMessage', msg);
+            localStorage.setItem('sensorDeleteMessage', msg);
             location.reload();
           }
         })
@@ -274,15 +215,23 @@
         });
       }
 
+      function populateIpAddress() {
+        var scanned_ip = document.getElementById("sensorDropDown").value;
+
+        if (scanned_ip != "--select--") {
+          document.getElementById("ipAddressInput").value = scanned_ip;
+        }
+      }
+
       function scan() {
         document.getElementById("scan").disabled = true;
         document.body.style.cursor = 'wait';
 
-        $.getJSON("/devices/scan", function(response){
+        $.getJSON("/sensors/scan", function(response){
           if (!response.error) {
-            var dropdown = $("#deviceDropDown");
+            var dropdown = $("#sensorDropDown");
             dropdown.empty();
-
+            console.log(response)
             $.each(response, function(key, value) {
               dropdown.append($("<option></option>").attr("value", value).text(value));
             });
@@ -297,18 +246,18 @@
         });
       }
 
-      // After page is refreshed show device snackbar info
+      // After page is refreshed show sensor snackbar info
       window.onload = function() {
         document.body.style.cursor = 'default';
-        const deviceAddMessage = localStorage.getItem('deviceAddMessage');
-        const deviceDeleteMessage = localStorage.getItem('deviceDeleteMessage');
+        const sensorAddMessage = localStorage.getItem('sensorAddMessage');
+        const sensorDeleteMessage = localStorage.getItem('sensorDeleteMessage');
 
-        if (deviceAddMessage) {
-          updateSnackbar(deviceAddMessage, "rgb(121, 196, 137)");
-          localStorage.removeItem('deviceAddMessage');
-        } else if (deviceDeleteMessage) {
-          updateSnackbar(deviceDeleteMessage, "rgb(121, 196, 137)");
-          localStorage.removeItem('deviceDeleteMessage');
+        if (sensorAddMessage) {
+          updateSnackbar(sensorAddMessage, "rgb(121, 196, 137)");
+          localStorage.removeItem('sensorAddMessage');
+        } else if (sensorDeleteMessage) {
+          updateSnackbar(sensorDeleteMessage, "rgb(121, 196, 137)");
+          localStorage.removeItem('sensorDeleteMessage');
         }
       };
 
@@ -323,15 +272,6 @@
 
         // After 3 seconds, remove the show class from DIV
         setTimeout(function(){ x.className = x.className.replace("show", ""); }, 3000);
-      }
-
-      function updateTelemetryText(slider) {
-        var telem_text = slider.nextElementSibling;
-        telem_text.innerHTML = slider.value;
-
-        slider.oninput = function() {
-          telem_text.innerHTML = this.value;
-        }
       }
     </script>
 


### PR DESCRIPTION
# Summary
We now have the ability to add sensors to users. This can be used in the future to trigger devices. As of now, it is purely informational.

## What I did here
- Add Sensor model as a base class with fields all sensors will have
- Add TemperatureSensor model which extends Sensor
- Tweaked Device Repo to use `device_id` instead of `user_id`
- Add TemperatureSensor Repo
- Add Sensor routes (similar to device routes)
- Tweaked `mqtt.py` to now listen and subscribe to topic structure: `<prefix>/<command>/` where `<prefix>` is `<component>_<component_id>_<component_name>`
```
e.g "sensors_1_shellyplusht-csd89dfhifsd/status"
```
- Add frontend sensors page, can search for sensors on network
- Changed settings tab to an icon placed on far right on the navbar

## How to test
-
