### PR TITLE
Reopen Streams Upon NVR Restart

### DIFF
--- a/application/services/video/video_stream.py
+++ b/application/services/video/video_stream.py
@@ -8,6 +8,7 @@ class VideoStream:
     def __init__(self, resolution=(640,480), framerate=30, stream_url=""):
         # Initialize the PiCamera and the camera image stream
         self.stream = cv2.VideoCapture(stream_url)
+        self.stream_url = stream_url
         ret = self.stream.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*'MJPG'))
         ret = self.stream.set(3,resolution[0])
         ret = self.stream.set(4,resolution[1])
@@ -34,6 +35,10 @@ class VideoStream:
 
             # Otherwise, grab the next frame from the stream
             (self.grabbed, self.frame) = self.stream.read()
+
+            if not self.grabbed:
+                self.stream.release()
+                self.stream = cv2.VideoCapture(self.stream_url)
 
     def read(self):
 	# Return the most recent frame

--- a/driver.py
+++ b/driver.py
@@ -158,7 +158,11 @@ if __name__ == "__main__":
     for idx, cam_name in enumerate(object_detection.CAMERAS):
         channel_str= "channel=" + str(idx + 1)
         stream = VideoStream(resolution=(object_detection.imW,object_detection.imH), framerate=30, stream_url=STREAM_URL.replace("channel=1", channel_str))
-        object_detection.CAMERAS.update({cam_name:[stream.start(), None, 0]})
+
+        if idx == 0:
+            object_detection.CAMERAS.update({cam_name:[stream.start(), None, 1]})
+        else:
+            object_detection.CAMERAS.update({cam_name:[stream.start(), None, 0]})
 
     # start a thread that will perform motion detection
     t = threading.Thread(target=object_detection.detection)


### PR DESCRIPTION
# Summary
Some NVR's have an auto reboot option. When the NVR restarts, camera stream RTSP connections are disconnected. Now, we are able to re-establish these lost connections so that the streams persist.

## What I did here
- Catch a return boolean on cv2's `read()` function
- Use above boolean to re-establish connections
- Default camera 1 to have detection auto enabled

## How to test
-
